### PR TITLE
fix(修复菜单删除异常): 调整了菜单删除的执行顺序，先删除关联缓存和权限按钮，再删除菜单本身。

### DIFF
--- a/panis-boot-modules/src/main/java/com/izpan/modules/system/service/impl/SysMenuServiceImpl.java
+++ b/panis-boot-modules/src/main/java/com/izpan/modules/system/service/impl/SysMenuServiceImpl.java
@@ -65,14 +65,12 @@ public class SysMenuServiceImpl extends ServiceImpl<SysMenuMapper, SysMenu> impl
 
     @Override
     public boolean batchDeleteMenu(List<Long> menuIds) {
-        boolean removeBatchByIds = super.removeBatchByIds(menuIds, true);
-        if (Boolean.TRUE.equals(removeBatchByIds)) {
-            // 删除角色缓存
-            menuIds.forEach(sysRoleMenuService::deleteRoleMenuCacheWithMenuId);
-            // 删除权限按钮数据
-            sysPermissionService.deletePermissionWithMenuIds(menuIds);
-        }
-        return removeBatchByIds;
+        // 删除角色缓存
+        menuIds.forEach(sysRoleMenuService::deleteRoleMenuCacheWithMenuId);
+        // 删除权限按钮数据
+        sysPermissionService.deletePermissionWithMenuIds(menuIds);
+        // 删除菜单
+        return super.removeBatchByIds(menuIds, true);
     }
 
     @Override


### PR DESCRIPTION
删除菜单后进入deleteRoleMenucacheWithMenuId时
![image](https://github.com/user-attachments/assets/3ba5984d-d2c4-40ea-ae29-77fcd3a7b50c)
导致sysMenuService.getById的sysMenu为null
![image](https://github.com/user-attachments/assets/d7dc3c2a-b182-41d1-a734-423558177d14)
![image](https://github.com/user-attachments/assets/169a90f6-49f0-4454-a9b7-2f871b6a0e0d)

